### PR TITLE
feat: ignore snyk jwt security issue that does not apply

### DIFF
--- a/snyk/.snyk
+++ b/snyk/.snyk
@@ -10,4 +10,8 @@ ignore:
     - '*':
         reason: false positive
         expires: 2021-01-01T00:00:00
+  SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515:
+    - '*':
+        reason: does not apply
+        expires: 2021-01-01T00:00:00
 # patch: {}


### PR DESCRIPTION
Ignoring https://app.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515 per approval of the security working group meeting on December 2, 2020 as our JWT usage doesn't utilize the audience behavior that is vulnerable